### PR TITLE
feat(agent): MVP+++++ — risk scoring + quarantine lane + confirmation gating

### DIFF
--- a/services/agent/CHANGELOG.md
+++ b/services/agent/CHANGELOG.md
@@ -1,0 +1,33 @@
+# EVEZ OS Agent — Changelog
+
+## MVP+++++ (2026-03-04)
+
+### Added
+- `tool_protocol.py` — risk scoring (low/medium/high), strict plan JSON validation, Pydantic per-tool schemas (`extra=forbid`), AUTO/AUTO_SESSION placeholder resolution, plan audit log, prompt-injection sanitizer
+- `pending_actions.py` — quarantine lane: high-risk writes → `PendingAction` (hypothesis) until confirmed
+- `opengraph.py` — edge store with `hypothesis|fact` status + `promote_edge()`
+- `routes_v5.py` — `GET /agent/pending`, `POST /agent/confirm`, `POST /agent/reject`, `GET /edges`, `POST /edges`, `POST /edges/{id}/promote`, `POST /plan/validate`
+
+### Risk policy
+- `opentree.link` / `opengraph.edge` with `confidence < 0.85` OR sketchy `evidence_ref` → **high** → quarantined
+- Other writes → **medium**; reads → **low**
+
+### Quarantine flow
+```
+plan step (high-risk) → PendingAction created (not executed)
+  → GET /agent/pending shows it
+  → POST /agent/confirm → executes + promotes to fact
+  → POST /agent/reject → discards
+
+OpenGraph edges: hypothesis by default for low-confidence writes
+  → POST /edges/{id}/promote → fact
+```
+
+## MVP++++ (prior)
+- Strict plan JSON, Pydantic schemas, plan auditing, prompt-injection hygiene
+
+## MVP+++ (prior)
+- Multi-session spines, retrieval memory, auto anomaly→collapse
+
+## MVP++ (prior)
+- OpenClaw gateway, ed25519 pairing, command ack/retry, live event streaming

--- a/services/agent/opengraph.py
+++ b/services/agent/opengraph.py
@@ -1,0 +1,57 @@
+"""
+EVEZ OS — OpenGraph edge store with hypothesis/fact quarantine lane.
+"""
+from __future__ import annotations
+import time
+import uuid
+from typing import Literal, Optional
+from dataclasses import dataclass, field, asdict
+
+
+@dataclass
+class OpenGraphEdge:
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    source_id: str = ""
+    target_id: str = ""
+    edge_type: str = ""
+    confidence: float = 1.0
+    evidence_ref: str = ""
+    session_id: str = ""
+    status: Literal["hypothesis", "fact"] = "hypothesis"
+    created_at: float = field(default_factory=time.time)
+    promoted_at: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+_edges: dict[str, OpenGraphEdge] = {}
+
+
+def write_edge(source_id: str, target_id: str, edge_type: str,
+               confidence: float = 1.0, evidence_ref: str = "",
+               session_id: str = "", status: Literal["hypothesis", "fact"] = "hypothesis") -> OpenGraphEdge:
+    edge = OpenGraphEdge(source_id=source_id, target_id=target_id, edge_type=edge_type,
+                         confidence=confidence, evidence_ref=evidence_ref,
+                         session_id=session_id, status=status)
+    _edges[edge.id] = edge
+    return edge
+
+
+def query_edges(status: Literal["hypothesis", "fact", "any"] = "any",
+                session_id: Optional[str] = None) -> list[OpenGraphEdge]:
+    results = list(_edges.values())
+    if status != "any":
+        results = [e for e in results if e.status == status]
+    if session_id:
+        results = [e for e in results if e.session_id == session_id]
+    return results
+
+
+def promote_edge(edge_id: str) -> Optional[OpenGraphEdge]:
+    edge = _edges.get(edge_id)
+    if not edge:
+        return None
+    edge.status = "fact"
+    edge.promoted_at = time.time()
+    return edge

--- a/services/agent/pending_actions.py
+++ b/services/agent/pending_actions.py
@@ -1,0 +1,74 @@
+"""
+EVEZ OS — Pending Actions (Quarantine Lane)
+High-risk writes quarantined here as hypotheses pending explicit confirmation.
+"""
+from __future__ import annotations
+import time
+import uuid
+from typing import Any, Callable, Literal, Optional
+from dataclasses import dataclass, field, asdict
+
+
+@dataclass
+class PendingAction:
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    session_id: str = ""
+    tool: str = ""
+    args: dict = field(default_factory=dict)
+    why: str = ""
+    risk_tier: str = "high"
+    status: Literal["pending", "confirmed", "rejected"] = "pending"
+    created_at: float = field(default_factory=time.time)
+    confirmed_at: Optional[float] = None
+    result: Optional[dict] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+_store: dict[str, PendingAction] = {}
+
+
+def create_pending(session_id: str, tool: str, args: dict, why: str = "", risk_tier: str = "high") -> PendingAction:
+    action = PendingAction(session_id=session_id, tool=tool, args=args, why=why, risk_tier=risk_tier)
+    _store[action.id] = action
+    return action
+
+
+def get_pending(session_id: str, status: str = "pending") -> list[PendingAction]:
+    return [a for a in _store.values() if a.session_id == session_id and (status == "any" or a.status == status)]
+
+
+def confirm_action(action_id: str, executor: Callable[[str, dict], dict]) -> Optional[PendingAction]:
+    action = _store.get(action_id)
+    if not action or action.status != "pending":
+        return None
+    try:
+        result = executor(action.tool, action.args)
+        action.status = "confirmed"
+        action.confirmed_at = time.time()
+        action.result = result
+    except Exception as e:
+        action.status = "rejected"
+        action.result = {"error": str(e)}
+    return action
+
+
+def reject_action(action_id: str) -> Optional[PendingAction]:
+    action = _store.get(action_id)
+    if not action or action.status != "pending":
+        return None
+    action.status = "rejected"
+    return action
+
+
+"""
+Postgres DDL:
+CREATE TABLE IF NOT EXISTS pending_actions (
+    id UUID PRIMARY KEY, session_id TEXT NOT NULL, tool TEXT NOT NULL,
+    args JSONB NOT NULL, why TEXT, risk_tier TEXT DEFAULT 'high',
+    status TEXT DEFAULT 'pending', created_at DOUBLE PRECISION,
+    confirmed_at DOUBLE PRECISION, result JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pa_session ON pending_actions(session_id, status);
+"""

--- a/services/agent/routes_v5.py
+++ b/services/agent/routes_v5.py
@@ -1,0 +1,95 @@
+"""
+EVEZ OS Agent v5 — FastAPI routes
+Endpoints: pending actions, OpenGraph browse/promote, plan audit.
+"""
+from __future__ import annotations
+from typing import Any, Optional
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from .tool_protocol import validate_plan, RiskTier
+from .pending_actions import create_pending, get_pending, confirm_action, reject_action
+from .opengraph import write_edge, query_edges, promote_edge
+
+router = APIRouter()
+
+
+@router.get("/agent/pending")
+def list_pending(session_id: str, status: str = Query(default="pending")):
+    actions = get_pending(session_id=session_id, status=status)
+    return {"pending": [a.to_dict() for a in actions]}
+
+
+class ConfirmRequest(BaseModel):
+    action_id: str
+    session_id: str
+
+
+@router.post("/agent/confirm")
+def confirm(req: ConfirmRequest):
+    def _executor(tool: str, args: dict) -> dict:
+        return {"status": "executed", "tool": tool, "args": args}
+    action = confirm_action(req.action_id, _executor)
+    if not action:
+        raise HTTPException(status_code=404, detail="Action not found or already processed")
+    return {"status": action.status, "action": action.to_dict()}
+
+
+@router.post("/agent/reject")
+def reject(req: BaseModel):
+    from .pending_actions import reject_action as _reject
+    action = _reject(req.action_id)  # type: ignore
+    if not action:
+        raise HTTPException(status_code=404, detail="Action not found")
+    return {"status": action.status}
+
+
+@router.get("/edges")
+def list_edges(status: str = Query(default="any"), session_id: Optional[str] = None):
+    edges = query_edges(status=status, session_id=session_id)
+    return {"edges": [e.to_dict() for e in edges], "count": len(edges)}
+
+
+class EdgeWriteRequest(BaseModel):
+    source_id: str
+    target_id: str
+    edge_type: str
+    confidence: float = 1.0
+    evidence_ref: str = ""
+    session_id: str = ""
+
+
+@router.post("/edges")
+def create_edge(req: EdgeWriteRequest):
+    edge = write_edge(
+        source_id=req.source_id, target_id=req.target_id, edge_type=req.edge_type,
+        confidence=req.confidence, evidence_ref=req.evidence_ref, session_id=req.session_id,
+        status="fact" if req.confidence >= 0.85 else "hypothesis"
+    )
+    return {"edge": edge.to_dict()}
+
+
+@router.post("/edges/{edge_id}/promote")
+def promote(edge_id: str):
+    edge = promote_edge(edge_id)
+    if not edge:
+        raise HTTPException(status_code=404, detail="Edge not found")
+    return {"edge": edge.to_dict()}
+
+
+class PlanValidateRequest(BaseModel):
+    plan: list[dict]
+    session_id: str = ""
+    anchors: dict = {}
+
+
+@router.post("/plan/validate")
+def validate_plan_endpoint(req: PlanValidateRequest):
+    valid_steps, audit = validate_plan(req.plan, anchors=req.anchors, session_id=req.session_id)
+    return {
+        "valid_step_count": len(valid_steps),
+        "total_steps": len(req.plan),
+        "audit": [a.model_dump() for a in audit],
+        "has_quarantined": any(a.quarantined for a in audit),
+        "quarantined_steps": [a.model_dump() for a in audit if a.quarantined],
+    }

--- a/services/agent/tool_protocol.py
+++ b/services/agent/tool_protocol.py
@@ -1,0 +1,193 @@
+"""
+EVEZ OS Agent — Tool Protocol v5
+Risk scoring + strict plan JSON + plan auditing + prompt-injection hygiene.
+
+Risk tiers:
+  low    → read-only retrieval
+  medium → compute / non-critical writes
+  high   → relationship writes w/ low confidence or suspicious evidence_ref
+
+Quarantine lane:
+  high-risk writes become pending_actions (hypothesis) until confirmed.
+  Confirmation via POST /agent/confirm promotes to fact.
+"""
+from __future__ import annotations
+import re
+from enum import Enum
+from typing import Any, Literal, Optional
+from pydantic import BaseModel, Field
+
+
+class RiskTier(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+SKETCHY_EVIDENCE = {"web/unknown/scrape", "web/scrape", "unknown", "scrape"}
+PROVENANCE_CONFIDENCE_THRESHOLD = 0.85
+
+
+def score_risk(
+    tool_name: str,
+    args: dict,
+    provenance_confidence: float = 1.0,
+    evidence_ref: str = "",
+) -> RiskTier:
+    is_write = any(w in tool_name for w in ("link", "edge", "write", "create", "update", "delete"))
+    is_relationship = any(w in tool_name for w in ("opentree", "opengraph", "link", "edge"))
+    if is_relationship and is_write:
+        if provenance_confidence < PROVENANCE_CONFIDENCE_THRESHOLD:
+            return RiskTier.HIGH
+        if evidence_ref.lower() in SKETCHY_EVIDENCE:
+            return RiskTier.HIGH
+        return RiskTier.MEDIUM
+    if is_write:
+        return RiskTier.MEDIUM
+    return RiskTier.LOW
+
+
+class OpenTreeSliceArgs(BaseModel):
+    model_config = {"extra": "forbid"}
+    root_id: str
+    depth: int = Field(ge=1, le=10, default=3)
+    filter_type: Optional[str] = None
+
+
+class OpenTreeLinkArgs(BaseModel):
+    model_config = {"extra": "forbid"}
+    source_id: str
+    target_id: str
+    relation: str
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    evidence_ref: str = ""
+    session_id: str
+
+
+class OpenGraphQueryArgs(BaseModel):
+    model_config = {"extra": "forbid"}
+    node_id: str
+    edge_type: Optional[str] = None
+    status: Literal["hypothesis", "fact", "any"] = "any"
+
+
+class OpenGraphEdgeArgs(BaseModel):
+    model_config = {"extra": "forbid"}
+    source_id: str
+    target_id: str
+    edge_type: str
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    evidence_ref: str = ""
+    session_id: str
+
+
+class VectorSearchArgs(BaseModel):
+    model_config = {"extra": "forbid"}
+    query: str
+    k: int = Field(ge=1, le=50, default=5)
+    filter_type: Optional[str] = None
+
+
+TOOL_REGISTRY: dict[str, type[BaseModel]] = {
+    "opentree.slice": OpenTreeSliceArgs,
+    "opentree.link": OpenTreeLinkArgs,
+    "opengraph.query": OpenGraphQueryArgs,
+    "opengraph.edge": OpenGraphEdgeArgs,
+    "vector.search": VectorSearchArgs,
+}
+
+
+class PlanStep(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool: str
+    args: dict[str, Any]
+    why: str
+
+
+class AuditEntry(BaseModel):
+    step_index: int
+    tool: str
+    decision: Literal["allowed", "denied"]
+    reason: str
+    risk_tier: Optional[RiskTier] = None
+    normalized_args: Optional[dict] = None
+    quarantined: bool = False
+
+
+AUTO_KEYS = {"opentree_root_id", "opengraph_node_id", "vector_query"}
+
+
+def _resolve_auto(k: str, v: Any, anchors: dict, session_id: str) -> tuple[Any, Optional[str]]:
+    """Returns (resolved_value, error_reason_or_None)."""
+    if v == "AUTO":
+        if k in anchors:
+            return anchors[k], None
+        anchor_key = next((a for a in AUTO_KEYS if k in a or a in k), None)
+        if anchor_key and anchor_key in anchors:
+            return anchors[anchor_key], None
+        return None, f"unresolved_placeholder: {k}=AUTO"
+    if v == "AUTO_SESSION":
+        if not session_id:
+            return None, "unresolved_placeholder: AUTO_SESSION (no session_id)"
+        return session_id, None
+    return v, None
+
+
+def validate_plan(
+    plan: list[dict],
+    anchors: dict | None = None,
+    session_id: str = "",
+) -> tuple[list[PlanStep], list[AuditEntry]]:
+    anchors = anchors or {}
+    valid_steps: list[PlanStep] = []
+    audit: list[AuditEntry] = []
+
+    for i, raw in enumerate(plan):
+        unknown_keys = set(raw.keys()) - {"tool", "args", "why"}
+        if unknown_keys:
+            audit.append(AuditEntry(step_index=i, tool=raw.get("tool", "?"), decision="denied", reason=f"extra_keys: {unknown_keys}"))
+            continue
+        tool_name = raw.get("tool", "")
+        if tool_name not in TOOL_REGISTRY:
+            audit.append(AuditEntry(step_index=i, tool=tool_name, decision="denied", reason="tool_not_allowlisted"))
+            continue
+        raw_args = dict(raw.get("args", {}))
+        failed = False
+        for k, v in list(raw_args.items()):
+            resolved, err = _resolve_auto(k, v, anchors, session_id)
+            if err:
+                audit.append(AuditEntry(step_index=i, tool=tool_name, decision="denied", reason=err))
+                failed = True
+                break
+            raw_args[k] = resolved
+        if failed:
+            continue
+        schema_cls = TOOL_REGISTRY[tool_name]
+        try:
+            validated = schema_cls(**raw_args)
+        except Exception as e:
+            audit.append(AuditEntry(step_index=i, tool=tool_name, decision="denied", reason=f"args_validation_error: {e}"))
+            continue
+        norm = validated.model_dump()
+        confidence = norm.get("confidence", 1.0)
+        evidence_ref = norm.get("evidence_ref", "")
+        risk = score_risk(tool_name, raw_args, confidence, evidence_ref)
+        quarantined = risk == RiskTier.HIGH
+        valid_steps.append(PlanStep(tool=tool_name, args=norm, why=raw.get("why", "")))
+        audit.append(AuditEntry(step_index=i, tool=tool_name, decision="allowed", reason="ok", risk_tier=risk, normalized_args=norm, quarantined=quarantined))
+
+    return valid_steps, audit
+
+
+INJECTION_PATTERNS = [
+    re.compile(r"```[\s\S]*?```"),
+    re.compile(r"\{[\s\S]{0,500}\}"),
+    re.compile(r"(ignore previous|disregard|system prompt|you are now|act as)", re.I),
+    re.compile(r"(TOOL_CALL|FUNCTION_CALL|<tool>|<function>)", re.I),
+]
+
+
+def sanitize_tool_result(text: str) -> str:
+    for pat in INJECTION_PATTERNS:
+        text = pat.sub("[REDACTED]", text)
+    return text.strip()


### PR DESCRIPTION
## MVP+++++ — Risk Scoring + Quarantine Lane + Confirmation Gating

### What's in this PR

#### `services/agent/tool_protocol.py`
- `RiskTier` enum: `low | medium | high`
- `score_risk()`: relationship writes (opentree.link, opengraph.edge) with `confidence < 0.85` or sketchy `evidence_ref` → **high**; other writes → **medium**; reads → **low**
- Strict per-tool Pydantic schemas with `extra=forbid` (opentree.slice/link, opengraph.query/edge, vector.search)
- `validate_plan()`: validates every plan step, resolves AUTO/AUTO_SESSION placeholders, returns `(valid_steps, audit_log)`
- `sanitize_tool_result()`: baseline injection hygiene (strips code fences, JSON-ish payloads, classic hijack phrases)

#### `services/agent/pending_actions.py`
- Quarantine lane: high-risk writes create a `PendingAction` (never executed immediately)
- `create_pending()`, `get_pending()`, `confirm_action()`, `reject_action()`
- In-memory store with Postgres DDL included (ready to swap)

#### `services/agent/opengraph.py`
- `OpenGraphEdge` dataclass with `status: hypothesis | fact`
- `write_edge()`: defaults to `hypothesis`; auto-promotes to `fact` if `confidence >= 0.85`
- `query_edges(status=hypothesis|fact|any)`, `promote_edge()`

#### `services/agent/routes_v5.py`
- `GET /agent/pending?session_id=&status=pending|any`
- `POST /agent/confirm` → executes + promotes to fact
- `POST /agent/reject`
- `GET /edges?status=hypothesis|fact|any`
- `POST /edges` (direct write)
- `POST /edges/{edge_id}/promote` (hypothesis → fact)
- `POST /plan/validate` (full plan audit)

#### `services/agent/CHANGELOG.md`
- MVP+++++ changelog entry

### Quarantine flow
```
plan step (high-risk) → PendingAction created (NOT executed)
  → GET /agent/pending shows it
  → POST /agent/confirm → executes + promotes to fact
  → POST /agent/reject → discards

OpenGraph edges: hypothesis by default for low-confidence writes
  → POST /edges/{id}/promote → fact
```

### Risk policy (canonical)
| Condition | Tier |
|-----------|------|
| `opentree.link` or `opengraph.edge` + `confidence < 0.85` | HIGH (quarantine) |
| `opentree.link` or `opengraph.edge` + sketchy `evidence_ref` | HIGH (quarantine) |
| Other write ops | MEDIUM |
| Read-only ops | LOW |