### PR TITLE
feat: Dockerize full EVEZ-OS stack — 5 images + compose + GHA build-push

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,94 @@
+name: EVEZ-OS Docker Build & Push
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'core/**'
+      - 'services/**'
+      - 'agents/**'
+      - 'terminals/**'
+      - 'assistants/**'
+      - 'memory/**'
+      - 'identity/**'
+      - 'docker/**'
+  workflow_dispatch:
+
+env:
+  DOCKER_HUB_USERNAME: evezart
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: spine
+            dockerfile: docker/Dockerfile.spine
+            image: evezart/evez-os-spine
+          - name: services
+            dockerfile: docker/Dockerfile.services
+            image: evezart/evez-os-services
+          - name: agents
+            dockerfile: docker/Dockerfile.agents
+            image: evezart/evez-os-agents
+          - name: terminals
+            dockerfile: docker/Dockerfile.terminals
+            image: evezart/evez-os-terminals
+          - name: riley-x
+            dockerfile: docker/Dockerfile.riley
+            image: evezart/evez-os-riley-x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+  notify-spine:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - name: Emit build event to Ably Spine
+        run: |
+          curl -s -X POST \
+            "https://rest.ably.io/channels/evez%2Fci%2Fevents/messages" \
+            -u "${{ secrets.ABLY_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "name": "build_success",
+              "data": {
+                "sha": "${{ github.sha }}",
+                "ref": "${{ github.ref_name }}",
+                "images": ["spine","services","agents","terminals","riley-x"]
+              }
+            }'

--- a/docker/Dockerfile.agents
+++ b/docker/Dockerfile.agents
@@ -1,0 +1,11 @@
+# evez-os-agents — Spider, Patrol, Recon
+FROM node:20-alpine AS agents-base
+WORKDIR /app
+COPY agents/package*.json ./
+RUN npm ci --only=production
+COPY agents/ .
+EXPOSE 3003
+ENV NODE_ENV=production
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD wget -qO- http://localhost:3003/health || exit 1
+CMD ["node", "index.mjs"]

--- a/docker/Dockerfile.riley
+++ b/docker/Dockerfile.riley
@@ -1,0 +1,11 @@
+# evez-os-riley-x — Voice terminal (Deepgram + Groq + ElevenLabs + LMNT)
+FROM node:20-alpine AS riley-base
+WORKDIR /app
+COPY assistants/package*.json ./
+RUN npm ci --only=production
+COPY assistants/ .
+EXPOSE 3005
+ENV NODE_ENV=production
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD wget -qO- http://localhost:3005/health || exit 1
+CMD ["node", "riley-x.mjs"]

--- a/docker/Dockerfile.services
+++ b/docker/Dockerfile.services
@@ -1,0 +1,11 @@
+# evez-os-services — Vision-Gate, AI-Forge, Oracle, Convert-Engine
+FROM node:20-alpine AS services-base
+WORKDIR /app
+COPY services/package*.json ./
+RUN npm ci --only=production
+COPY services/ .
+EXPOSE 3002
+ENV NODE_ENV=production
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD wget -qO- http://localhost:3002/health || exit 1
+CMD ["node", "index.mjs"]

--- a/docker/Dockerfile.spine
+++ b/docker/Dockerfile.spine
@@ -1,0 +1,11 @@
+# evez-os-spine — Ably-Spine + Backendless-Registry
+FROM node:20-alpine AS spine-base
+WORKDIR /app
+COPY core/package*.json ./
+RUN npm ci --only=production
+COPY core/ .
+EXPOSE 3001
+ENV NODE_ENV=production
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD wget -qO- http://localhost:3001/health || exit 1
+CMD ["node", "ably-spine.mjs"]

--- a/docker/Dockerfile.terminals
+++ b/docker/Dockerfile.terminals
@@ -1,0 +1,13 @@
+# evez-os-terminals — Discord, AgentMail, SMS, WhatsApp, Memory, Identity
+FROM node:20-alpine AS terminals-base
+WORKDIR /app
+COPY terminals/package*.json ./
+RUN npm ci --only=production
+COPY terminals/ .
+COPY memory/ ./memory/
+COPY identity/ ./identity/
+EXPOSE 3004
+ENV NODE_ENV=production
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD wget -qO- http://localhost:3004/health || exit 1
+CMD ["node", "index.mjs"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,186 @@
+version: "3.9"
+
+# ============================================================
+# EVEZ-OS FULL STACK — docker-compose.yml
+# 5 containers + shared env, healthchecks, restart policies
+# docker compose up --build
+# ============================================================
+
+x-common-env: &common-env
+  NODE_ENV: production
+  ABLY_API_KEY: ${ABLY_API_KEY}
+  BACKENDLESS_APP_ID: ${BACKENDLESS_APP_ID}
+  BACKENDLESS_API_KEY: ${BACKENDLESS_API_KEY}
+
+services:
+
+  spine:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.spine
+    image: evezart/evez-os-spine:latest
+    container_name: evez-spine
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    environment:
+      <<: *common-env
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    networks:
+      - evez-net
+    volumes:
+      - spine-data:/app/data
+
+  services:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.services
+    image: evezart/evez-os-services:latest
+    container_name: evez-services
+    restart: unless-stopped
+    ports:
+      - "3002:3002"
+    depends_on:
+      spine:
+        condition: service_healthy
+    environment:
+      <<: *common-env
+      GOOGLE_CLOUD_VISION_API_KEY: ${GOOGLE_CLOUD_VISION_API_KEY}
+      ASTICA_API_KEY: ${ASTICA_API_KEY}
+      ALL_IMAGES_AI_API_KEY: ${ALL_IMAGES_AI_API_KEY}
+      GROQ_API_KEY: ${GROQ_API_KEY}
+      AIML_API_KEY: ${AIML_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      PERPLEXITY_API_KEY: ${PERPLEXITY_API_KEY}
+      YOUSEARCH_API_KEY: ${YOUSEARCH_API_KEY}
+      JIGSAWSTACK_API_KEY: ${JIGSAWSTACK_API_KEY}
+      CLOUDCONVERT_API_KEY: ${CLOUDCONVERT_API_KEY}
+      CONVERTAPI_SECRET: ${CONVERTAPI_SECRET}
+      MEM0_API_KEY: ${MEM0_API_KEY}
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - evez-net
+
+  agents:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.agents
+    image: evezart/evez-os-agents:latest
+    container_name: evez-agents
+    restart: unless-stopped
+    ports:
+      - "3003:3003"
+    depends_on:
+      spine:
+        condition: service_healthy
+      services:
+        condition: service_healthy
+    environment:
+      <<: *common-env
+      AGENTQL_API_KEY: ${AGENTQL_API_KEY}
+      HYPERBROWSER_API_KEY: ${HYPERBROWSER_API_KEY}
+      BROWSEAI_API_KEY: ${BROWSEAI_API_KEY}
+      AGENTY_API_KEY: ${AGENTY_API_KEY}
+      MICROSOFT_CLARITY_PROJECT_ID: ${MICROSOFT_CLARITY_PROJECT_ID}
+      ANCHOR_BROWSER_API_KEY: ${ANCHOR_BROWSER_API_KEY}
+      GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY}
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3003/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - evez-net
+
+  terminals:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.terminals
+    image: evezart/evez-os-terminals:latest
+    container_name: evez-terminals
+    restart: unless-stopped
+    ports:
+      - "3004:3004"
+    depends_on:
+      spine:
+        condition: service_healthy
+      services:
+        condition: service_healthy
+    environment:
+      <<: *common-env
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
+      AGENT_MAIL_API_KEY: ${AGENT_MAIL_API_KEY}
+      CLICKSEND_USERNAME: ${CLICKSEND_USERNAME}
+      CLICKSEND_API_KEY: ${CLICKSEND_API_KEY}
+      TWOCHAT_API_KEY: ${TWOCHAT_API_KEY}
+      TWOCHAT_ACCOUNT_ID: ${TWOCHAT_ACCOUNT_ID}
+      TWITTER_API_KEY: ${TWITTER_API_KEY}
+      TWITTER_API_SECRET: ${TWITTER_API_SECRET}
+      TWITTER_ACCESS_TOKEN_EVEZ666: ${TWITTER_ACCESS_TOKEN_EVEZ666}
+      TWITTER_ACCESS_SECRET_EVEZ666: ${TWITTER_ACCESS_SECRET_EVEZ666}
+      TWITTER_ACCESS_TOKEN_STEVEN: ${TWITTER_ACCESS_TOKEN_STEVEN}
+      TWITTER_ACCESS_SECRET_STEVEN: ${TWITTER_ACCESS_SECRET_STEVEN}
+      MEM0_API_KEY: ${MEM0_API_KEY}
+      MEM0_NAMESPACE: evez-os
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3004/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - evez-net
+
+  riley-x:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.riley
+    image: evezart/evez-os-riley-x:latest
+    container_name: evez-riley
+    restart: unless-stopped
+    ports:
+      - "3005:3005"
+    depends_on:
+      spine:
+        condition: service_healthy
+      services:
+        condition: service_healthy
+    environment:
+      <<: *common-env
+      DEEPGRAM_API_KEY: ${DEEPGRAM_API_KEY}
+      AIVOOV_API_KEY: ${AIVOOV_API_KEY}
+      GROQ_API_KEY: ${GROQ_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ELEVENLABS_API_KEY: ${ELEVENLABS_API_KEY}
+      LMNT_API_KEY: ${LMNT_API_KEY}
+      VAPI_API_KEY: ${VAPI_API_KEY}
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3005/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - evez-net
+
+networks:
+  evez-net:
+    driver: bridge
+
+volumes:
+  spine-data:
+    driver: local


### PR DESCRIPTION
## Dockerize full EVEZ-OS stack ◊

**5 images. 1 compose file. 1 GHA pipeline. Zero manual failover.**

---

### What's in this PR

| File | Purpose |
|------|---------|
| `docker/Dockerfile.spine` | `evezart/evez-os-spine` — Ably-Spine + Backendless-Registry |
| `docker/Dockerfile.services` | `evezart/evez-os-services` — Vision-Gate, AI-Forge, Oracle, Convert-Engine |
| `docker/Dockerfile.agents` | `evezart/evez-os-agents` — AgentQL-Spider, Agenty-Patrol, Anchor-Recon |
| `docker/Dockerfile.terminals` | `evezart/evez-os-terminals` — Discord, AgentMail, SMS, WhatsApp, Identity, Mem0 |
| `docker/Dockerfile.riley` | `evezart/evez-os-riley-x` — Voice terminal (Deepgram→ElevenLabs→LMNT) |
| `docker/docker-compose.yml` | Full stack orchestration: healthchecks, restart policies, evez-net bridge, spine-data volume |
| `.github/workflows/docker-build-push.yml` | Matrix build → push all 5 images to Docker Hub on every `main` push + notify Ably Spine |

---

### Startup order
```
spine (health gate)
  └── services (depends: spine healthy)
        └── agents (depends: spine + services healthy)
        └── terminals (depends: spine + services healthy)
        └── riley-x (depends: spine + services healthy)
```

### Run locally
```bash
cd docker
cp .env.example .env
# fill in API keys
docker compose up --build
```

### Run on any host
```bash
docker pull evezart/evez-os-spine:latest
docker pull evezart/evez-os-services:latest
docker pull evezart/evez-os-agents:latest
docker pull evezart/evez-os-terminals:latest
docker pull evezart/evez-os-riley-x:latest
# or:
docker compose -f docker/docker-compose.yml up
```

### CI/CD
- Push to `main` → GHA builds all 5 images in parallel matrix
- Tags: `main-{sha}` + `latest`
- GHA cache enabled (speeds up subsequent builds)
- On success: POST to `evez/ci/events` Ably channel (spine notified)

### One requirement before merging
Add `DOCKER_HUB_TOKEN` to GitHub repo secrets (Settings → Secrets → Actions).
Value: Docker Hub → Account Settings → Security → New Access Token.

---

Commit: `15d7f78b76b4c7691f02616851a347a438d9507f` ◊