### PR TITLE
Align evez-os skill/install docs with actual CLI paths and strengthen smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,21 @@ on:
       - main
 
 jobs:
-  lint:
+  cli-smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Basic sanity
+
+      - name: Run CLI sanity checks
         run: |
-          python -c "import json; import pathlib; p=pathlib.Path('docs/chart_object.json'); print('chart_object.json exists:', p.exists())"
-          python -c "import pathlib; p=pathlib.Path('spine/EVENT_SPINE.jsonl'); print('EVENT_SPINE.jsonl exists:', p.exists())"
-          echo "CI sanity: PASS"
+          python tools/evez.py --help
+          python tools/evez.py verify
+          python tools/evez.py lint
+          python tools/run_all.py --help
+
+      - name: Run smoke tests
+        run: |
+          python -m unittest tests.test_cli_smoke -v

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,6 @@ maps failure surfaces, and generates infinite adversarial missions from its own 
 ## Quick Start
 
 ```bash
-cd core
 python3 tools/evez.py init
 python3 tools/evez.py play --seed 42 --steps 14
 ```
@@ -35,7 +34,7 @@ python3 tools/evez.py play --seed 42 --steps 14
 ## One-Command Demo
 
 ```bash
-cd core && python3 tools/run_all.py --seed --mode spicy
+python3 tools/run_all.py --seed --mode spicy
 ```
 
 ## Play Forever
@@ -49,7 +48,7 @@ python3 tools/evez.py play --loop --steps 14
 ```bash
 pkg install python
 git clone https://github.com/EvezArt/evez-os.git
-cd evez-os/core
+cd evez-os
 python tools/evez.py init
 python tools/run_all.py --seed --mode spicy
 ```

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+from pathlib import Path
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestCliSmoke(unittest.TestCase):
+    def run_cmd(self, *args):
+        return subprocess.run(
+            [sys.executable, *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_evez_help(self):
+        result = self.run_cmd("tools/evez.py", "--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("usage", result.stdout.lower())
+
+    def test_evez_verify(self):
+        result = self.run_cmd("tools/evez.py", "verify")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("verify", result.stdout.lower())
+
+    def test_run_all_help(self):
+        result = self.run_cmd("tools/run_all.py", "--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("seed", result.stdout.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR addresses the highest-value extension surface drift in `evez-os` by reconciling install/skill docs with the real root-level CLI, and upgrading CI from file-existence checks to command-level smoke validation.

## What changed
- Updated `SKILL.md` commands to match real repo layout:
  - removed stale `cd core` quickstart/demo path assumptions
  - fixed Termux instructions from `cd evez-os/core` to `cd evez-os`
- Replaced shallow `.github/workflows/ci.yml` checks with executable smoke checks:
  - `python tools/evez.py --help`
  - `python tools/evez.py verify`
  - `python tools/evez.py lint`
  - `python tools/run_all.py --help`
- Added `tests/test_cli_smoke.py` (`unittest`) to enforce CLI entrypoint sanity for:
  - `tools/evez.py --help`
  - `tools/evez.py verify`
  - `tools/run_all.py --help`

## Why
- Root-level entrypoints are the canonical install/run surface for EVEZ skill/plugin consumers.
- Prior CI could pass even when user-facing CLI behavior drifted.
- This keeps OpenClaw/ClawHub install semantics honest without inventing new architecture.

## Validation run locally
- `python tools/evez.py --help`
- `python tools/evez.py verify`
- `python tools/evez.py lint`
- `python tools/run_all.py --help`
- `python -m unittest tests.test_cli_smoke -v`

All commands completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0940ed464832eba9df195bc66d45c)