### PR TITLE
Reconcile root CLI docs with implemented command surface

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -60,14 +60,10 @@ Add to Termux:Boot for autorun — see ANDROID.md.
 
 | Command | What It Does |
 |---------|-------------|
-| `evez.py init` | Initialize event + ARG spines |
+| `evez.py lint` | Compile-check Python modules in `spine/` |
 | `evez.py play --seed N --steps N` | Generate forensic episode |
-| `evez.py play --loop` | Infinite self-play |
-| `evez.py cycle --ring R4 --anomaly "desc"` | Log FSC cycle |
-| `evez.py lint` | Audit spine for violations |
-| `evez.py arg-init` | Initialize ARG spine |
-| `evez.py arg-narrate --tail N` | Narrate from spine tail |
-| `evez.py trigger` | Auto-generate missions |
+| `evez.py visualize-thought --input spine.jsonl` | Render visual cognition artifacts |
+| `evez.py verify [target]` | Print repository integrity summary |
 | `self_cartography.py` | Mermaid + DOT diagrams |
 | `run_all.py --seed --mode spicy` | Full demo |
 

--- a/docs/SELF_CARTOGRAPHY_MAP.md
+++ b/docs/SELF_CARTOGRAPHY_MAP.md
@@ -17,7 +17,7 @@ evez-os/
 │   ├── san.py ✓ (Self-Auditing Narrator module)
 │   └── route_opt.py ✓ (latency ranking)
 ├── tools/
-│   ├── evez.py ✓ (v1.2.0 — 18 commands, visualize-thought)
+│   ├── evez.py ✓ (canonical root CLI: lint, play, visualize-thought, verify)
 │   ├── swarm_compress.py ✓ (Layer 1: 5 compute techniques)
 │   ├── hyperloop_engine.py ✓ (Layer 2: 5 acceleration techniques)
 │   ├── route_agg.py ✓ (multi-vantage aggregator)

--- a/tests/test_evez_cli_surface.py
+++ b/tests/test_evez_cli_surface.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import unittest
+
+
+class EvezCliSurfaceTests(unittest.TestCase):
+    def run_cli(self, *args):
+        return subprocess.run(
+            [sys.executable, "tools/evez.py", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_help_lists_canonical_subcommands(self):
+        result = self.run_cli("--help")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("{lint,play,visualize-thought,verify}", result.stdout)
+
+    def test_legacy_documented_command_not_available(self):
+        result = self.run_cli("cycle", "--help")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid choice", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- The canonical root CLI entrypoint `tools/evez.py` actually exposes only `lint`, `play`, `visualize-thought`, and `verify`, while higher-level docs still listed legacy commands like `cycle`, `arg-init`, `arg-narrate`, and `trigger`, producing documentation/implementation drift. 
- The goal is to truthfully reconcile user-facing command tables with the implemented surface using the smallest non-invasive fixes. 
- Avoid adding new engine behavior or inventing wrappers that would misrepresent the current root CLI.

### Description
- Updated the `All Commands` table in `SKILL.md` to list the actual root subcommands `lint`, `play`, `visualize-thought`, and `verify`, and removed legacy root-command entries. 
- Updated the brief `tools/evez.py` description in `docs/SELF_CARTOGRAPHY_MAP.md` to reflect the canonical root CLI surface instead of claiming "18 commands". 
- Added a small regression test `tests/test_evez_cli_surface.py` that asserts `python3 tools/evez.py --help` lists the canonical subcommands and that a legacy command (`cycle`) is rejected by the root parser.

### Testing
- Ran `python3 tools/evez.py --help` to confirm the displayed subcommands are `{lint,play,visualize-thought,verify}` and it returned successfully. 
- Ran `python3 -m unittest tests/test_evez_cli_surface.py` (2 tests) and both tests passed (`OK`). 
- No wrappers or behavioral changes were added to `tools/evez.py`; this batch is documentation + test only to prevent future drift.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b099bf5ca0832e93cf8c2f995e210e)