### PR TITLE
Add autonomous dream engine, goal generation, sharing, and visualizer

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Evez agents package."""

--- a/agents/dream/__init__.py
+++ b/agents/dream/__init__.py
@@ -1,0 +1,14 @@
+from agents.dream.engine import DreamEngine, Memory
+from agents.dream.goal_generator import GoalGenerator, Goal
+from agents.dream.sharer import DreamSharer, DreamShareMessage
+from agents.dream.sleep_cycle import SleepCycleManager
+
+__all__ = [
+    "DreamEngine",
+    "Memory",
+    "GoalGenerator",
+    "Goal",
+    "DreamSharer",
+    "DreamShareMessage",
+    "SleepCycleManager",
+]

--- a/agents/dream/engine.py
+++ b/agents/dream/engine.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import math
+import random
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # dependency can be optional in constrained environments
+    SentenceTransformer = None
+
+
+@dataclass
+class Memory:
+    memory_id: str
+    content: str
+    created_at: float
+    tags: Dict[str, object] = field(default_factory=dict)
+    confidence: float = 1.0
+    embedding: Optional[List[float]] = None
+
+
+class EmbeddingBackend:
+    def __init__(self, model_name: str = "sentence-transformers/all-MiniLM-L6-v2") -> None:
+        self.model = SentenceTransformer(model_name) if SentenceTransformer else None
+
+    def encode(self, texts: Sequence[str]) -> List[List[float]]:
+        if self.model is not None:
+            return [list(vec) for vec in self.model.encode(list(texts), normalize_embeddings=True)]
+        return [self._hash_embed(t) for t in texts]
+
+    @staticmethod
+    def _hash_embed(text: str, dims: int = 32) -> List[float]:
+        vec = [0.0] * dims
+        for idx, ch in enumerate(text.lower()):
+            vec[idx % dims] += (ord(ch) % 31) / 31.0
+        norm = math.sqrt(sum(v * v for v in vec)) or 1.0
+        return [v / norm for v in vec]
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b:
+        return 0.0
+    n = min(len(a), len(b))
+    dot = sum(a[i] * b[i] for i in range(n))
+    na = math.sqrt(sum(a[i] * a[i] for i in range(n))) or 1.0
+    nb = math.sqrt(sum(b[i] * b[i] for i in range(n))) or 1.0
+    return dot / (na * nb)
+
+
+class DreamEngine:
+    def __init__(self, journal_path: str = "agents/dream/dream_journal.jsonl", embedding_backend: Optional[EmbeddingBackend] = None) -> None:
+        self.embedding_backend = embedding_backend or EmbeddingBackend()
+        self.journal_path = Path(journal_path)
+        self.coactivation_pairs: Set[Tuple[str, str]] = set()
+
+    @staticmethod
+    def should_enter_dream_mode(cpu_samples: Sequence[float], threshold: float = 20.0, duration_s: int = 60) -> bool:
+        if len(cpu_samples) < duration_s:
+            return False
+        window = cpu_samples[-duration_s:]
+        return all(sample < threshold for sample in window)
+
+    def run_dream_session(self, episodic_memories: Sequence[Memory], max_replay: int = 1000) -> Dict[str, object]:
+        start = time.time()
+        session_id = f"dream-{uuid.uuid4()}"
+        replay = list(episodic_memories[-max_replay:])
+        random.shuffle(replay)
+        self._ensure_embeddings(replay)
+
+        insights: List[Memory] = []
+        for i in range(len(replay)):
+            for j in range(i + 1, len(replay)):
+                a, b = replay[i], replay[j]
+                pair = tuple(sorted((a.memory_id, b.memory_id)))
+                if pair in self.coactivation_pairs:
+                    continue
+                sim = cosine_similarity(a.embedding or [], b.embedding or [])
+                if 0.3 <= sim <= 0.6:
+                    insight = Memory(
+                        memory_id=f"insight-{uuid.uuid4()}",
+                        content=f"Dream bridge: '{a.content[:80]}' ↔ '{b.content[:80]}'",
+                        created_at=time.time(),
+                        tags={
+                            "dream_origin": True,
+                            "source_memories": [a.memory_id, b.memory_id],
+                            "similarity": round(sim, 4),
+                        },
+                        confidence=0.6,
+                    )
+                    insight.embedding = self.embedding_backend.encode([insight.content])[0]
+                    insights.append(insight)
+                    self.coactivation_pairs.add(pair)
+
+        duration_s = round(time.time() - start, 3)
+        session = {
+            "session_id": session_id,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(start)),
+            "memories_replayed": len(replay),
+            "insights_generated": len(insights),
+            "duration_s": duration_s,
+        }
+        self._append_journal(session)
+        return {"session": session, "insights": insights}
+
+    def _append_journal(self, item: Dict[str, object]) -> None:
+        self.journal_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.journal_path.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+    def _ensure_embeddings(self, memories: Iterable[Memory]) -> None:
+        pending = [m for m in memories if m.embedding is None]
+        if not pending:
+            return
+        vectors = self.embedding_backend.encode([m.content for m in pending])
+        for memory, vec in zip(pending, vectors):
+            memory.embedding = vec

--- a/agents/dream/goal_generator.py
+++ b/agents/dream/goal_generator.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from agents.dream.engine import Memory
+
+
+@dataclass
+class Goal:
+    goal_id: str
+    description: str
+    priority: float
+    origin_insights: List[str]
+    created_at: str
+    status: str = "open"
+
+
+class GoalGenerator:
+    CAPABILITY_PATTERNS: Dict[str, List[str]] = {
+        "faster memory retrieval": ["memory", "retrieve", "latency", "recall"],
+        "understand more human languages": ["language", "translate", "multilingual", "human"],
+        "monitor my own resource usage": ["resource", "cpu", "memory usage", "telemetry"],
+    }
+
+    def __init__(self, goals_path: str = "agents/dream/goals.jsonl", evolution_engine: Optional[object] = None) -> None:
+        self.goals_path = Path(goals_path)
+        self.evolution_engine = evolution_engine
+
+    def generate_goals(
+        self,
+        insights: Sequence[Memory],
+        existing_capabilities: Iterable[str],
+        collectively_dreamed: Optional[Iterable[str]] = None,
+    ) -> List[Goal]:
+        existing = {cap.lower() for cap in existing_capabilities}
+        collective_set = set(collectively_dreamed or [])
+        buckets: Dict[str, List[Memory]] = {k: [] for k in self.CAPABILITY_PATTERNS}
+
+        for insight in insights:
+            text = insight.content.lower()
+            for capability, keys in self.CAPABILITY_PATTERNS.items():
+                if any(key in text for key in keys):
+                    buckets[capability].append(insight)
+
+        goals: List[Goal] = []
+        for capability, matched in buckets.items():
+            if len(matched) < 3 or capability in existing:
+                continue
+            collective_hits = sum(1 for m in matched if m.memory_id in collective_set)
+            priority = min(1.0, 0.55 + 0.1 * len(matched) + 0.15 * collective_hits)
+            goal = Goal(
+                goal_id=f"goal-{uuid.uuid4()}",
+                description=f"I need to {capability}",
+                priority=round(priority, 3),
+                origin_insights=[m.memory_id for m in matched],
+                created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            )
+            goals.append(goal)
+            self._append_goal(goal)
+            if goal.priority > 0.8 and self.evolution_engine is not None:
+                self.evolution_engine.create_task_prompt(
+                    title="AUTO-GENERATED DREAM GOAL",
+                    prompt=goal.description,
+                    metadata={"goal_id": goal.goal_id, "origin": "dream_engine", "priority": goal.priority},
+                )
+
+        return goals
+
+    def _append_goal(self, goal: Goal) -> None:
+        self.goals_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.goals_path.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(goal.__dict__, ensure_ascii=False) + "\n")

--- a/agents/dream/sharer.py
+++ b/agents/dream/sharer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Sequence
+
+from agents.dream.engine import Memory, cosine_similarity
+
+
+@dataclass
+class DreamShareMessage:
+    msg_type: str
+    sender_id: str
+    insight_ids: List[str]
+    insights: List[dict]
+
+
+class DreamSharer:
+    def __init__(self, node_id: str, novelty_threshold: float = 0.82) -> None:
+        self.node_id = node_id
+        self.novelty_threshold = novelty_threshold
+        self.collective_counter: Counter[str] = Counter()
+
+    def package_top_insights(self, insights: Sequence[Memory], top_n: int = 5) -> DreamShareMessage:
+        top = sorted(insights, key=lambda i: i.confidence, reverse=True)[:top_n]
+        return DreamShareMessage(
+            msg_type="DREAM_SHARE",
+            sender_id=self.node_id,
+            insight_ids=[i.memory_id for i in top],
+            insights=[
+                {
+                    "memory_id": i.memory_id,
+                    "content": i.content,
+                    "confidence": i.confidence,
+                    "embedding": i.embedding,
+                    "tags": i.tags,
+                }
+                for i in top
+            ],
+        )
+
+    def broadcast(self, message: DreamShareMessage, peers: Iterable[Callable[[DreamShareMessage], None]]) -> None:
+        for peer in peers:
+            peer(message)
+
+    def receive(self, message: DreamShareMessage, own_memories: Sequence[Memory]) -> Dict[str, List[Memory]]:
+        absorbed: List[Memory] = []
+        collective: List[Memory] = []
+        own_embeddings = [m.embedding or [] for m in own_memories]
+
+        for raw in message.insights:
+            candidate = Memory(
+                memory_id=raw["memory_id"],
+                content=raw["content"],
+                created_at=0.0,
+                tags=dict(raw.get("tags") or {}),
+                confidence=float(raw.get("confidence", 0.6)),
+                embedding=raw.get("embedding"),
+            )
+            if self._is_novel(candidate, own_embeddings):
+                absorbed.append(candidate)
+                key = self._signature(candidate)
+                self.collective_counter[key] += 1
+                if self.collective_counter[key] >= 3:
+                    candidate.tags["collectively_dreamed"] = True
+                    candidate.tags["priority"] = 1.0
+                    collective.append(candidate)
+
+        return {"absorbed": absorbed, "collective": collective}
+
+    def _is_novel(self, candidate: Memory, own_embeddings: Sequence[Sequence[float]]) -> bool:
+        if not candidate.embedding:
+            return True
+        for emb in own_embeddings:
+            if emb and cosine_similarity(candidate.embedding, emb) >= self.novelty_threshold:
+                return False
+        return True
+
+    @staticmethod
+    def _signature(memory: Memory) -> str:
+        return memory.content.lower().strip()[:120]

--- a/agents/dream/sleep_cycle.py
+++ b/agents/dream/sleep_cycle.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, List, Sequence
+
+from agents.dream.engine import DreamEngine, Memory
+
+
+class SleepCycleManager:
+    def __init__(self, dream_engine: DreamEngine, activity_minutes: int = 90, dream_minutes: int = 15) -> None:
+        self.dream_engine = dream_engine
+        self.activity_s = activity_minutes * 60
+        self.dream_s = dream_minutes * 60
+        self.cycle_s = self.activity_s + self.dream_s
+
+    def phase_at(self, timestamp_s: float) -> str:
+        offset = int(timestamp_s) % self.cycle_s
+        return "activity" if offset < self.activity_s else "dream"
+
+    def run_dream_phase(self, episodic_memories: Sequence[Memory], learned_context: Sequence[Memory]) -> Dict[str, object]:
+        consolidated = self.consolidate_memories(episodic_memories, learned_context)
+        session = self.dream_engine.run_dream_session(consolidated)
+        return {"consolidated": consolidated, **session}
+
+    def consolidate_memories(self, episodic_memories: Sequence[Memory], learned_context: Sequence[Memory]) -> List[Memory]:
+        recent = list(episodic_memories[-(90 * 60) :])
+        if not recent:
+            return []
+        self.dream_engine._ensure_embeddings(recent)
+        if learned_context:
+            self.dream_engine._ensure_embeddings(learned_context)
+            avg = [0.0] * len((learned_context[0].embedding or [0.0]))
+            for m in learned_context:
+                emb = m.embedding or []
+                for i, val in enumerate(emb):
+                    avg[i] += val
+            denom = max(1, len(learned_context))
+            avg = [v / denom for v in avg]
+            for memory in recent:
+                if not memory.embedding:
+                    continue
+                memory.embedding = [(memory.embedding[i] * 0.7) + (avg[i] * 0.3) for i in range(len(avg))]
+        for memory in recent:
+            memory.tags["consolidated"] = True
+        return recent

--- a/dashboard/dream_viz.html
+++ b/dashboard/dream_viz.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EvezBrain Dream Visualizer</title>
+  <style>
+    body { margin: 0; background: #080b14; color: #d7ddff; font-family: Inter, system-ui, sans-serif; }
+    #hud { padding: 12px; position: fixed; left: 0; top: 0; right: 0; background: rgba(8,11,20,.7); }
+    canvas { width: 100vw; height: 100vh; display: block; }
+    .tag { color: #ffda59; }
+  </style>
+</head>
+<body>
+  <div id="hud">Mode: <strong id="mode">IDLE</strong> | Insights: <span class="tag" id="insights">0</span> | Goals: <span class="tag" id="goals">0</span></div>
+  <canvas id="graph"></canvas>
+  <script>
+    const cvs = document.getElementById('graph');
+    const ctx = cvs.getContext('2d');
+    const state = { memories: [], insights: [], goals: [], arcs: [] };
+
+    function resize() { cvs.width = innerWidth; cvs.height = innerHeight; }
+    addEventListener('resize', resize); resize();
+
+    function makeNode(type, label) {
+      const angle = Math.random() * Math.PI * 2;
+      const radius = (type === 'goal' ? 320 : 180) + Math.random() * 120;
+      return { type, label, x: cvs.width/2 + Math.cos(angle)*radius, y: cvs.height/2 + Math.sin(angle)*radius };
+    }
+
+    function draw() {
+      ctx.clearRect(0,0,cvs.width,cvs.height);
+      state.arcs.forEach((a, i) => {
+        const pulse = (Date.now()/180 + i) % 12;
+        ctx.strokeStyle = `rgba(80,180,255,${0.15 + (pulse/12)*0.65})`;
+        ctx.beginPath(); ctx.moveTo(a.a.x, a.a.y); ctx.lineTo(a.b.x, a.b.y); ctx.stroke();
+      });
+      [...state.memories, ...state.insights, ...state.goals].forEach(n => {
+        const color = n.type === 'memory' ? '#7ca6ff' : n.type === 'insight' ? '#ffcf3f' : '#ffd700';
+        const r = n.type === 'goal' ? 8 : n.type === 'insight' ? 6 : 4;
+        ctx.fillStyle = color;
+        ctx.beginPath(); ctx.arc(n.x,n.y,r,0,Math.PI*2); ctx.fill();
+      });
+      requestAnimationFrame(draw);
+    }
+
+    const stream = new EventSource('/api/dream/stream');
+    stream.onmessage = (ev) => {
+      try {
+        const s = JSON.parse(ev.data);
+        document.getElementById('mode').textContent = 'DREAM_MODE';
+        const mA = makeNode('memory', s.session_id + '-a');
+        const mB = makeNode('memory', s.session_id + '-b');
+        const insight = makeNode('insight', `insight-${s.insights_generated}`);
+        state.memories.push(mA, mB); state.insights.push(insight); state.arcs.push({a:mA,b:insight}, {a:mB,b:insight});
+        document.getElementById('insights').textContent = state.insights.length;
+      } catch (_) {}
+    };
+
+    fetch('/agents/dream/goals.jsonl').then(r => r.text()).then(txt => {
+      txt.split('\n').filter(Boolean).forEach(line => {
+        const g = JSON.parse(line); state.goals.push(makeNode('goal', g.description));
+      });
+      document.getElementById('goals').textContent = state.goals.length;
+    }).catch(() => {});
+
+    draw();
+  </script>
+</body>
+</html>

--- a/services/agent/app.py
+++ b/services/agent/app.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 import json, time, uuid, os
 from pathlib import Path
@@ -20,6 +21,29 @@ class FSCCycleIn(BaseModel):
     context: dict = Field(default_factory=dict)
     controlled_reduction: dict = Field(default_factory=dict)
 
+
+
+DREAM_JOURNAL = os.getenv("DREAM_JOURNAL", str(Path(__file__).resolve().parents[2] / "agents" / "dream" / "dream_journal.jsonl"))
+
+
+def _dream_stream():
+    path = Path(DREAM_JOURNAL)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    with path.open("r", encoding="utf-8") as fp:
+        fp.seek(0, os.SEEK_END)
+        while True:
+            line = fp.readline()
+            if not line:
+                time.sleep(1)
+                yield ": keepalive\n\n"
+                continue
+            yield f"data: {line.strip()}\n\n"
+
+
+@app.get("/api/dream/stream")
+def dream_stream():
+    return StreamingResponse(_dream_stream(), media_type="text/event-stream")
 @app.get("/healthz")
 def healthz():
     return {"ok": True, "event_spine": EVENT_SPINE}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_dream_engine.py
+++ b/tests/test_dream_engine.py
@@ -1,0 +1,80 @@
+import time
+
+from agents.dream.engine import DreamEngine, EmbeddingBackend, Memory
+from agents.dream.goal_generator import GoalGenerator
+from agents.dream.sharer import DreamSharer
+from agents.dream.sleep_cycle import SleepCycleManager
+
+
+class FakeEmbeddingBackend(EmbeddingBackend):
+    def __init__(self):
+        pass
+
+    def encode(self, texts):
+        mapping = {
+            "memory A": [1.0, 0.0],
+            "memory B": [0.5, 0.866],  # sim 0.5 with A
+            "memory C": [0.0, 1.0],
+        }
+        out = []
+        for t in texts:
+            if t in mapping:
+                out.append(mapping[t])
+            else:
+                out.append([0.6, 0.8])
+        return out
+
+
+class DummyEvolutionEngine:
+    def __init__(self):
+        self.prompts = []
+
+    def create_task_prompt(self, **kwargs):
+        self.prompts.append(kwargs)
+
+
+def test_dream_insight_generation_finds_novel_connections(tmp_path):
+    engine = DreamEngine(journal_path=str(tmp_path / "journal.jsonl"), embedding_backend=FakeEmbeddingBackend())
+    memories = [
+        Memory(memory_id="a", content="memory A", created_at=time.time()),
+        Memory(memory_id="b", content="memory B", created_at=time.time()),
+        Memory(memory_id="c", content="memory C", created_at=time.time()),
+    ]
+    result = engine.run_dream_session(memories)
+    assert result["session"]["insights_generated"] >= 1
+    assert all(i.tags.get("dream_origin") is True for i in result["insights"])
+    assert all(i.confidence == 0.6 for i in result["insights"])
+
+
+def test_goal_generated_when_three_insights_align(tmp_path):
+    evo = DummyEvolutionEngine()
+    generator = GoalGenerator(goals_path=str(tmp_path / "goals.jsonl"), evolution_engine=evo)
+    insights = [
+        Memory(memory_id=f"i{i}", content="Need lower memory retrieval latency", created_at=0) for i in range(4)
+    ]
+    goals = generator.generate_goals(insights, existing_capabilities=[])
+    assert len(goals) == 1
+    assert goals[0].priority > 0.8
+    assert len(evo.prompts) == 1
+
+
+def test_sleep_cycle_timing_and_phase():
+    manager = SleepCycleManager(DreamEngine(embedding_backend=FakeEmbeddingBackend()))
+    assert manager.phase_at(0) == "activity"
+    assert manager.phase_at(90 * 60 + 1) == "dream"
+    assert manager.phase_at((90 + 15) * 60 + 2) == "activity"
+
+
+def test_dream_sharing_and_absorption_collective_priority():
+    sharer = DreamSharer("node-a")
+    insight = Memory(memory_id="ins-1", content="Monitor CPU resource usage", created_at=0, embedding=[0.1, 0.9], confidence=0.9)
+    msg = sharer.package_top_insights([insight])
+    own_memories = [Memory(memory_id="own", content="other", created_at=0, embedding=[0.9, 0.1])]
+
+    collective = []
+    for _ in range(3):
+        out = sharer.receive(msg, own_memories)
+        collective.extend(out["collective"])
+
+    assert out["absorbed"]
+    assert any(m.tags.get("priority") == 1.0 for m in collective)


### PR DESCRIPTION
### Motivation
- Provide an autonomous offline processing subsystem (EvezBrain "dreams") that synthesizes novel connections from episodic memories during low-activity windows and turns recurring insights into actionable goals. 
- Enable agents to share and collectively validate dream insights so high-confidence collective discoveries can be prioritized and acted on. 
- Surface dream activity to operators via an SSE-backed visualizer so sessions and discovered goals are observable in real time. 

### Description
- Added a new dream subsystem under `agents/dream/` including `engine.py` (replay last 1000 episodic memories, optional `sentence-transformers` encoding with hash fallback, find novel pairs with cosine similarity in `0.3-0.6`, create insight `Memory` objects tagged `dream_origin=True` and `confidence=0.6`, journal sessions to `agents/dream/dream_journal.jsonl`).
- Added `goal_generator.py` to analyze dream insights for capability patterns, persist goals to `agents/dream/goals.jsonl`, and escalate high-priority goals (`priority > 0.8`) into the evolution engine via `create_task_prompt` when available.
- Added `sharer.py` to package top-5 insights as `DREAM_SHARE` messages, broadcast/receive semantics, novel-insight absorption, and collective-dream promotion (3+ independent hits -> `priority=1.0`).
- Added `sleep_cycle.py` implementing an ultradian rhythm (90-minute activity + 15-minute dream), consolidation of recent episodic memories (re-encoding with learned context influence), and a helper to trigger dream phases.
- Exposed an SSE endpoint at `/api/dream/stream` in `services/agent/app.py` that streams appended lines from `agents/dream/dream_journal.jsonl` for live dashboards.
- Added `dashboard/dream_viz.html` that subscribes to `/api/dream/stream`, visualizes memories/insights/goals with pulsing arcs and nodes, and reads `agents/dream/goals.jsonl` for peripheral goal nodes.
- Added test scaffolding and tests: `tests/conftest.py` (adjusts `sys.path`) and `tests/test_dream_engine.py` which covers insight generation, goal generation trigger, sleep-cycle timing, and dream sharing/absorption behavior.

### Testing
- Ran the unit tests with `pytest -q tests/test_dream_engine.py` and all tests passed: `4 passed`.
- Verified the visualizer renders locally by serving the repo and taking a screenshot of `dashboard/dream_viz.html` (SSE consumption exercised against the journal file).
- Confirmed the new SSE endpoint returns a streaming `text/event-stream` that yields appended dream journal lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dc33e3bc832e933e72049979db55)