### PR TITLE
chore: add EVEZ version contract and checker

### DIFF
--- a/.evez-versions
+++ b/.evez-versions
@@ -1,0 +1,16 @@
+{
+  "schema": 1,
+  "ecosystem": "evez",
+  "updated_at": "2026-03-19",
+  "versions": {
+    "python": "3.11",
+    "fastapi": "0.115.0",
+    "uvicorn": "0.30.0",
+    "httpx": "0.27.0",
+    "groq": "0.9.0",
+    "agno": "1.2.0",
+    "evez-os": "0.1.0",
+    "evez-agentnet": "1.0.0",
+    "openclaw": "2.1.0"
+  }
+}

--- a/.github/workflows/evez-version-contract.yml
+++ b/.github/workflows/evez-version-contract.yml
@@ -1,0 +1,76 @@
+name: evez-version-contract
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  contract:
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate .evez-versions structure
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+
+          path = pathlib.Path('.evez-versions')
+          if not path.exists():
+              raise SystemExit('Missing .evez-versions')
+
+          data = json.loads(path.read_text(encoding='utf-8'))
+          if data.get('schema') != 1:
+              raise SystemExit(f"Expected schema=1, found {data.get('schema')!r}")
+          if data.get('ecosystem') != 'evez':
+              raise SystemExit(f"Expected ecosystem=\"evez\", found {data.get('ecosystem')!r}")
+
+          versions = data.get('versions')
+          if not isinstance(versions, dict):
+              raise SystemExit('versions must be an object')
+
+          required = {
+              'python',
+              'fastapi',
+              'uvicorn',
+              'httpx',
+              'groq',
+              'agno',
+              'evez-os',
+              'evez-agentnet',
+              'openclaw',
+          }
+          missing = sorted(required - set(versions))
+          if missing:
+              raise SystemExit(f'Missing required version pins: {missing}')
+
+          print('Contract structure OK')
+          PY
+
+      - name: Compile checker
+        run: python -m py_compile scripts/check_versions.py
+
+      - name: Smoke-test checker against python contract subset
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+
+          path = pathlib.Path('.evez-versions')
+          data = json.loads(path.read_text(encoding='utf-8'))
+          python_pin = data['versions']['python']
+          data['versions'] = {'python': python_pin}
+          path.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+          print('Reduced contract to python-only subset for deterministic CI smoke test')
+          PY
+
+          python scripts/check_versions.py

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate local runtime/package versions against .evez-versions.
+
+Usage:
+    python scripts/check_versions.py
+
+Exits non-zero when one or more pinned versions do not match the current
+Python runtime or installed package versions.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from importlib import metadata
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / ".evez-versions"
+
+PACKAGE_NAME_MAP = {
+    "python": None,
+    "evez-os": None,
+    "evez-agentnet": None,
+    "openclaw": "openclaw",
+    "fastapi": "fastapi",
+    "uvicorn": "uvicorn",
+    "httpx": "httpx",
+    "groq": "groq",
+    "agno": "agno",
+}
+
+
+def read_contract() -> dict:
+    if not CONTRACT.exists():
+        raise FileNotFoundError(f"Missing contract file: {CONTRACT}")
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def installed_version(package_name: str) -> str | None:
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def main() -> int:
+    contract = read_contract()
+    versions = contract.get("versions", {})
+    failures: list[str] = []
+
+    expected_python = versions.get("python")
+    if expected_python:
+        current_python = f"{sys.version_info.major}.{sys.version_info.minor}"
+        if current_python != expected_python:
+            failures.append(
+                f"python expected {expected_python} but found {current_python}"
+            )
+
+    for key, expected in versions.items():
+        mapped = PACKAGE_NAME_MAP.get(key)
+        if mapped is None:
+            continue
+        current = installed_version(mapped)
+        if current is None:
+            failures.append(f"{key} expected {expected} but package is not installed")
+            continue
+        if current != expected:
+            failures.append(f"{key} expected {expected} but found {current}")
+
+    if failures:
+        print("EVEZ version contract mismatch detected:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    print("EVEZ version contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the shared `.evez-versions` contract and `scripts/check_versions.py` so `evez-os` can participate in the cross-repo version pinning/CI strategy without bypassing protected branch rules.

Included:
- `.evez-versions`
- `scripts/check_versions.py`

Reason:
- protected main branch blocked direct commit due to deployment + signature rules
- this PR preserves review/merge flow while landing the contract work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the shared `.evez-versions` contract and a checker script to enforce pinned Python and core EVEZ package versions across repos. Adds a GitHub Actions workflow to validate the contract and smoke‑test the checker in CI without breaking protected-branch review flow.

- **New Features**
  - `.evez-versions` (schema 1) defines pins for Python and core deps (`fastapi`, `uvicorn`, `httpx`, `groq`, `agno`, `evez-os`, `evez-agentnet`, `openclaw`).
  - `scripts/check_versions.py` validates the Python minor version and installed packages via `importlib.metadata`, exiting non‑zero with clear messages on mismatches.
  - `.github/workflows/evez-version-contract.yml` checks contract schema and required keys, compiles the checker, and runs a python‑only smoke test on push/PR to `main`.

<sup>Written for commit 4901be0e3670f8f1e556a027004b4f94847b71d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

