### PR TITLE
fix: enforce falsifier gate on /tasks spine endpoint (Constitutional Rule #2)

### DIFF
--- a/core/spine.py
+++ b/core/spine.py
@@ -1,5 +1,8 @@
 """Spine module — append-only event log operations.
 Bridge module for tools/evez.py (v1.2.0 Visual Cognition Layer).
+
+Constitutional Rule #2: No claim without falsifier.
+Events of kind=*.event MUST include a 'falsifier' field or they are rejected.
 """
 from __future__ import annotations
 
@@ -14,6 +17,30 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 HASH_ALG = "sha256"
 GENESIS_HASH = "0" * 64  # Genesis block hash — all zeros
+
+
+class FalsifierGateError(ValueError):
+    """Raised when an event violates Constitutional Rule #2."""
+    pass
+
+
+def _validate_falsifier_gate(event: Dict[str, Any]) -> None:
+    """Constitutional Rule #2: no claim without falsifier.
+    
+    Events with kind ending in '.event' require a non-null 'falsifier' field.
+    This prevents gossip (unverifiable claims) from corrupting the proof ledger.
+    """
+    kind = event.get("kind") or event.get("type") or ""
+    
+    # Gate applies to *.event kinds and 'claim' kinds
+    if kind.endswith(".event") or kind == "claim":
+        falsifier = event.get("falsifier")
+        if falsifier is None or (isinstance(falsifier, str) and falsifier.strip() == ""):
+            raise FalsifierGateError(
+                f"Constitutional Rule #2 violation: kind='{kind}' requires a non-null 'falsifier' field. "
+                f"Event rejected to prevent unverifiable claims in the proof ledger. "
+                f"trace_id={event.get('trace_id', '?')}"
+            )
 
 
 
@@ -52,7 +79,11 @@ def append_event(path: Path, event: Dict[str, Any]) -> Dict[str, Any]:
     """Append event to spine with auto-generated hash and timestamp.
     Args: path first, event second (matching tools/evez.py calling convention).
     Returns: event dict with 'hash' key added.
+    Raises: FalsifierGateError if event violates Constitutional Rule #2.
     """
+    # Pre-write validation: enforce falsifier gate
+    _validate_falsifier_gate(event)
+
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/evez_game/spine.py
+++ b/evez_game/spine.py
@@ -14,8 +14,11 @@ Hash computation:
 
 "event_without_hash_fields" excludes keys: "hash", "prev_hash", "sig".
 
+Constitutional Rule #2: No claim without falsifier.
+Events of kind=*.event MUST include a 'falsifier' field or they are rejected.
+
 This module supports:
-- append_event(...): appends with correct chain fields
+- append_event(...): appends with correct chain fields (falsifier-gated)
 - read_events(...): streaming reader
 - lint(...): verifies chain + basic invariants
 """
@@ -34,6 +37,29 @@ HASH_ALG = "sha256"
 GENESIS_HASH = hashlib.sha256(b"EVEZ-SPINE-GENESIS").hexdigest()
 
 HASH_FIELDS = {"hash", "prev_hash", "sig"}
+
+
+class FalsifierGateError(ValueError):
+    """Raised when an event violates Constitutional Rule #2."""
+    pass
+
+
+def _validate_falsifier_gate(event: Dict[str, Any]) -> None:
+    """Constitutional Rule #2: no claim without falsifier.
+    
+    Events with kind ending in '.event' require a non-null 'falsifier' field.
+    This prevents gossip (unverifiable claims) from corrupting the proof ledger.
+    """
+    kind = event.get("kind") or event.get("type") or ""
+    
+    if kind.endswith(".event") or kind == "claim":
+        falsifier = event.get("falsifier")
+        if falsifier is None or (isinstance(falsifier, str) and falsifier.strip() == ""):
+            raise FalsifierGateError(
+                f"Constitutional Rule #2 violation: kind='{kind}' requires a non-null 'falsifier' field. "
+                f"Event rejected to prevent unverifiable claims in the proof ledger. "
+                f"trace_id={event.get('trace_id', '?')}"
+            )
 
 
 def _strip_hash_fields(event: Dict[str, Any]) -> Dict[str, Any]:
@@ -70,9 +96,15 @@ def read_events(path: Path) -> Iterator[Dict[str, Any]]:
             yield json.loads(line)
 
 
-def append_event(path: Path, event: Dict[str, Any]) -> Dict[str, Any]:
-    """Append an event to the spine with correct hash chaining."""
+def append_event(path: Path, event: Dict[str, Any]) -> Dict[str]:
+    """Append an event to the spine with correct hash chaining.
+    
+    Raises: FalsifierGateError if event violates Constitutional Rule #2.
+    """
     import json
+
+    # Pre-write validation: enforce falsifier gate
+    _validate_falsifier_gate(event)
 
     path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Fixes #3

## Problem
The spine endpoint accepts `kind=*.event` payloads missing a `falsifier` field and writes them without rejection. This violates Constitutional Rule #2: no claim without falsifier.

## Solution
Added pre-write validation in `append_event()` that rejects any event where:
- `kind` ends with `.event` OR `kind == 'claim'`
- `falsifier` is null or empty string

A clear `FalsifierGateError` is raised with the trace_id and rule reference.

## Changes
- `core/spine.py`: Added `FalsifierGateError`, `_validate_falsifier_gate()`, gate in `append_event()`
- `evez_game/spine.py`: Same gate added

## Tests
All 4 test cases pass:
1. ✅ Event without falsifier → rejected
2. ✅ Event with falsifier → accepted
3. ✅ Non-event kind → not gated
4. ✅ Claim without falsifier → rejected

---
*Morpheus — autonomous development engine*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Constitutional Rule #2 on spine appends. Events with kind `*.event` or `claim` must include a non-empty `falsifier`, otherwise the write is rejected to protect the ledger.

- **Bug Fixes**
  - Added `_validate_falsifier_gate()` and pre-write check in `append_event()`; raises `FalsifierGateError` with `trace_id`.
  - Applied in `core/spine.py` and `evez_game/spine.py`; non-event kinds are unaffected.
  - Tests cover accept/reject cases for event, claim, and non-event kinds.

<sup>Written for commit 123ab2242226f34012a6941ad5df300f8e50f548. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

