### PR TITLE
feat: add keepalive workflow

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,31 @@
+name: Keepalive
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-enable all workflows
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wfs = await github.rest.actions.listRepoWorkflows({
+              owner: context.repo.owner, repo: context.repo.repo
+            });
+            for (const wf of wfs.data.workflows) {
+              if (wf.state !== 'active') {
+                await github.rest.actions.enableWorkflow({
+                  owner: context.repo.owner, repo: context.repo.repo, workflow_id: wf.id
+                });
+                console.log('Re-enabled:', wf.name);
+              }
+            }
+            console.log('Done.', new Date().toISOString());


### PR DESCRIPTION
Adds universal keepalive workflow to re-enable all workflows every 6h. Required for 24/7 operation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a keepalive GitHub Actions workflow that runs every 6 hours and re-enables any disabled workflows to keep automation running 24/7.

- **New Features**
  - Scheduled via cron '0 */6 * * *' with manual (`workflow_dispatch`) and push-to-main triggers.
  - Uses `actions/github-script@v7` with `actions: write` permissions.

<sup>Written for commit 72085ad9b5a1bdb585f662d1879ae8a9f75156df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

