### PR TITLE
FIRE Broadcast Workflow

### DIFF
--- a/.github/workflows/fire-broadcast.yml
+++ b/.github/workflows/fire-broadcast.yml
@@ -1,0 +1,36 @@
+name: FIRE Broadcast
+on:
+  repository_dispatch:
+    types: [fire_event]
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+
+jobs:
+  broadcast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Compute latest FIRE state
+        run: |
+          # Pull the latest fire round data
+          python3 -c "
+          import json, math
+          # Latest known round parameters
+          V_v2 = 1.911309
+          V_global = 1.657871
+          N = 41
+          cv = 43
+          narr_c = 1 - abs(V_v2 - V_global) / max(V_v2, V_global)
+          print(f'FIRE State: N={N} cv={cv} narr_c={narr_c:.4f}')
+          print(f'V_v2={V_v2} V_global={V_global}')
+          "
+      
+      - name: Signal lord-evez666
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/EvezArt/lord-evez666/dispatches \
+            -d '{"event_type":"revenue_bridge_signal","client_payload":{"source":"fire_broadcast","timestamp":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}}'
+          echo "Signal dispatched to lord-evez666"

--- a/os-evez/spine_adapter.py
+++ b/os-evez/spine_adapter.py
@@ -1,0 +1,65 @@
+"""
+Spine Adapter — bridges EVEZ-OS agent_bus events to evez-spine.
+Every agent event becomes a hash-chained spine entry.
+"""
+import sys
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+SPINE_LIB = Path(__file__).parent.parent.parent / "evez-spine"
+sys.path.insert(0, str(SPINE_LIB))
+from spine import Spine, Domain, Status, SignalClass
+
+EVENT_DOMAIN_MAP = {
+    "FIRE_EVENT": Domain.COGNITION, "OODA_CYCLE": Domain.AGENT,
+    "TASK_CREATED": Domain.AGENT, "TASK_COMPLETED": Domain.AGENT,
+    "AGENT_SPAWNED": Domain.AGENT, "AGENT_DIED": Domain.AGENT,
+    "ERROR": Domain.INFRA, "EVOLUTION": Domain.COGNITION,
+    "REPAIR": Domain.INFRA, "EXPANSION": Domain.COGNITION,
+    "MEMORY_CONSOLIDATION": Domain.CONSCIOUSNESS,
+    "CROSS_REPO": Domain.AGENT, "HEARTBEAT": Domain.INFRA,
+}
+EVENT_SIGNAL_MAP = {
+    "FIRE_EVENT": SignalClass.FIRE_EVENT,
+    "EVOLUTION": SignalClass.EIGENVALUE,
+    "ERROR": SignalClass.LOG_ONLY,
+}
+
+class SpineAdapter:
+    def __init__(self, spine_path: Optional[str] = None):
+        if spine_path and Path(spine_path).exists():
+            self.spine = Spine.from_file(spine_path)
+        else:
+            self.spine = Spine(operator="evez-os", genesis_meta={
+                "source": "agent_bus", "version": "1.0.0",
+                "eigenvalue_threshold": -0.358,
+            })
+        self.spine_path = spine_path
+
+    def ingest_event(self, event_type: str, payload: Dict[str, Any],
+                     caused_by: Optional[str] = None) -> Dict:
+        domain = EVENT_DOMAIN_MAP.get(event_type, Domain.AGENT)
+        signal = EVENT_SIGNAL_MAP.get(event_type, SignalClass.LOG_ONLY)
+        if event_type == "FIRE_EVENT" and "V_v2" in payload:
+            return self.spine.log_fire_round(payload, caused_by=caused_by)
+        if event_type == "OODA_CYCLE":
+            return self.spine.log_agent_cycle("OODA", payload, caused_by=caused_by)
+        return self.spine.log(event_type, payload, domain=domain.value,
+                              confidence=0.9, signal_class=signal.value,
+                              caused_by=caused_by, tags=[event_type.lower()])
+
+    def save(self):
+        if self.spine_path: self.spine.export(self.spine_path)
+    def get_eigenvalue_status(self) -> Dict: return self.spine.eigenvalue_status()
+    def get_fire_history(self) -> list: return self.spine.query(event_type="FIRE_ROUND", domain=Domain.COGNITION.value)
+    def get_agent_history(self) -> list: return self.spine.query(domain=Domain.AGENT.value)
+    def verify(self) -> tuple: return self.spine.verify_chain()
+
+if __name__ == "__main__":
+    a = SpineAdapter()
+    a.ingest_event("FIRE_EVENT", {"N": 32, "V_v2": 1.620825, "V_global": 1.45457, "cv": 34, "H_norm": 0.8657})
+    a.ingest_event("OODA_CYCLE", {"observe": 18, "orient": 5, "branch": "build", "act": "deployed"})
+    a.ingest_event("AGENT_SPAWNED", {"agent_id": "research", "model": "MiniMax-M2.5"})
+    a.ingest_event("HEARTBEAT", {"services": {"gateway": "UP"}})
+    print(json.dumps(a.spine.stats(), indent=2, default=str))
+    print(f"Chain: {a.verify()}")


### PR DESCRIPTION
Signals lord-evez666 every 6h + on repository_dispatch. Auto-generated by Viktor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the FIRE Broadcast GitHub Actions workflow to compute the latest FIRE state and signal `EvezArt/lord-evez666`, and adds a spine adapter that bridges agent events to `evez-spine`.

- **New Features**
  - FIRE Broadcast workflow: runs every 6h and on `repository_dispatch` (`fire_event`), computes FIRE metrics, and dispatches `revenue_bridge_signal` with a UTC timestamp.
  - `os-evez/spine_adapter.py`: maps agent_bus events to `evez-spine` domains/signals, logs `FIRE_EVENT` rounds, and exposes history, eigenvalue status, and chain verification helpers.

- **Migration**
  - Ensure the token used can dispatch to `EvezArt/lord-evez666`. If needed, add a PAT secret and use it in the curl command.

<sup>Written for commit 957a1fd0322dfda29bfc503a7c8eae3177818447. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

